### PR TITLE
Refactor Result class to use specific error type

### DIFF
--- a/AIERA.Desktop.WinForms/Authentication/Accounts/Microsoft/IMicrosoftAuthentication.cs
+++ b/AIERA.Desktop.WinForms/Authentication/Accounts/Microsoft/IMicrosoftAuthentication.cs
@@ -1,14 +1,13 @@
 ﻿using AIERA.Desktop.WinForms.Authentication.Models.Result_Pattern;
 using AIERA.Desktop.WinForms.Models.ViewModels;
-using Common.Models;
 using Microsoft.Identity.Client;
 
 namespace AIERA.Desktop.WinForms.Authentication.Accounts.Microsoft;
 
 public interface IMicrosoftAuthentication
 {
-    Task<Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError>> SignInAsync(nint? hWnd, IAccount? account, string? claims, CancellationToken cancellationoken = default);
-    Task<Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError>> SignInAsync(nint? hWnd, string? loginHint, string? identifier, string? claims, CancellationToken cancellationoken = default);
+    Task<Result<MicrosoftAccountViewModel>> SignInAsync(nint? hWnd, IAccount? account, string? claims, CancellationToken cancellationoken = default);
+    Task<Result<MicrosoftAccountViewModel>> SignInAsync(nint? hWnd, string? loginHint, string? identifier, string? claims, CancellationToken cancellationoken = default);
     Task SignOutAsync(AuthenticationResult authResult);
     Task SignOutAsync(IAccount account);
 }

--- a/AIERA.Desktop.WinForms/Authentication/Accounts/Microsoft/MicrosoftAuthentication.cs
+++ b/AIERA.Desktop.WinForms/Authentication/Accounts/Microsoft/MicrosoftAuthentication.cs
@@ -4,7 +4,6 @@ using AIERA.Desktop.WinForms.Models.ViewModels;
 using AIERA.Desktop.WinForms.Toaster;
 using AIERA.Desktop.WinForms.Toaster.Enums;
 using Common.Helpers;
-using Common.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 using System.Net.Sockets;
@@ -40,7 +39,7 @@ public partial class MicrosoftAuthentication : IMicrosoftAuthentication
     /// <returns></returns>
     ///     /// <exception cref="HttpRequestException">This exception is sometimes thrown when there is no internet connection.
     ///     It would then have an inner <see cref="SocketException"/> with a <see cref="SocketError.HostNotFound"/> error code indicating the host is unreachable.</exception>
-    public Task<Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError>> SignInAsync(nint? hWnd, IAccount? account, string? claims, CancellationToken cancellationToken = default)
+    public Task<Result<MicrosoftAccountViewModel>> SignInAsync(nint? hWnd, IAccount? account, string? claims, CancellationToken cancellationToken = default)
     {
         return SignInAsync(hWnd, account?.Username, account?.HomeAccountId.Identifier, claims, cancellationToken);
     }
@@ -56,7 +55,7 @@ public partial class MicrosoftAuthentication : IMicrosoftAuthentication
     /// <exception cref="HttpRequestException">This exception is sometimes thrown when there is no internet connection.
     ///     It would then have an inner <see cref="SocketException"/> with a <see cref="SocketError.HostNotFound"/> error code indicating the host is unreachable.</exception>
     /// <returns></returns>
-    public async Task<Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError>> SignInAsync(nint? hWnd, string? loginHint, string? identifier, string? claims, CancellationToken cancellationToken = default)
+    public async Task<Result<MicrosoftAccountViewModel>> SignInAsync(nint? hWnd, string? loginHint, string? identifier, string? claims, CancellationToken cancellationToken = default)
     {
         bool retry = false;
         string? errorMessage = null;
@@ -112,7 +111,7 @@ public partial class MicrosoftAuthentication : IMicrosoftAuthentication
                                                                               AuthResult: null,
                                                                               claims));
 
-        return Result.Fail<MicrosoftAccountViewModel, MicrosoftAuthenticationError>(error);
+        return Result.Fail<MicrosoftAccountViewModel>(error);
     }
 
     #region Toasts

--- a/AIERA.Desktop.WinForms/Authentication/Models/Result Pattern/MicrosoftAuthenticationError.cs
+++ b/AIERA.Desktop.WinForms/Authentication/Models/Result Pattern/MicrosoftAuthenticationError.cs
@@ -1,7 +1,10 @@
 ﻿using AIERA.Desktop.WinForms.Models.ViewModels;
 using Common.Models;
+using Microsoft.Identity.Client;
 
 namespace AIERA.Desktop.WinForms.Authentication.Models.Result_Pattern;
+
+
 public class MicrosoftAuthenticationError : Error
 {
     public MicrosoftAccountViewModel AccountViewModel { get; }
@@ -23,14 +26,17 @@ public class MicrosoftAuthenticationError : Error
         => new("MicrosoftAuthenticationError.HostNotFoundExceptionError", errorMessage, microsoftAccountViewModel);
     internal static MicrosoftAuthenticationError ExceptionError(string errorMessage, MicrosoftAccountViewModel microsoftAccountViewModel)
         => new("MicrosoftAuthenticationError.ExceptionError", errorMessage, microsoftAccountViewModel);
+
+    // General Errors
+    public static MicrosoftAuthenticationError TaskCancelledExceptionError(string errorMessage, IAccount account)
+    => new("Error.TaskCanceledException", errorMessage, new MicrosoftAccountViewModel(account, AuthResult: null, Claims: null));
 }
 
 
 
 public static class ResultExtensions
 {
-    public static MicrosoftAccountViewModel GetMicrosoftAccountViewModel(
-        this Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError> result)
+    public static MicrosoftAccountViewModel GetMicrosoftAccountViewModel(this Result<MicrosoftAccountViewModel> result)
     {
         return result.Match(success: value => value,
                             failure: error => error.AccountViewModel);

--- a/AIERA.Desktop.WinForms/Authentication/Models/Result Pattern/Result.cs
+++ b/AIERA.Desktop.WinForms/Authentication/Models/Result Pattern/Result.cs
@@ -1,5 +1,4 @@
-﻿namespace Common.Models;
-
+﻿namespace AIERA.Desktop.WinForms.Authentication.Models.Result_Pattern;
 
 /// <summary>
 /// A generic way of returning objects from a method. Also prevents exceptions being thrown back as communication
@@ -8,26 +7,26 @@ public class Result
 {
     public bool IsSuccess { get; private set; }
     public bool IsFailure => !IsSuccess;
-    public Error? Error { get; private set; }
+    public MicrosoftAuthenticationError? Error { get; private set; }
 
-    protected Result(bool success, Error? error)
+    protected Result(bool success, MicrosoftAuthenticationError? microsoftAuthenticationError)
     {
         IsSuccess = success;
-        Error = error;
+        Error = microsoftAuthenticationError;
     }
 
-    public static Result Fail(Error error) => new(success: false, error);
+    public static Result Fail(MicrosoftAuthenticationError microsoftAuthenticationError) => new(success: false, microsoftAuthenticationError);
 
-    public static Result<TValue> Fail<TValue>(Error error)
+    public static Result<TValue> Fail<TValue>(MicrosoftAuthenticationError microsoftAuthenticationError)
     {
-        return new Result<TValue>(value: default, success: false, error);
+        return new Result<TValue>(value: default, success: false, microsoftAuthenticationError);
     }
 
-    public static Result Ok() => new(success: true, error: null);
+    public static Result Ok() => new(success: true, microsoftAuthenticationError: null);
 
     public static Result<TValue> Ok<TValue>(TValue value)
     {
-        return new Result<TValue>(value, success: true, error: null);
+        return new Result<TValue>(value, success: true, microsoftAuthenticationError: null);
     }
 
     public static Result Combine(params Result[] results)
@@ -61,11 +60,10 @@ public class Result<TValue> : Result
         private set { _value = value; }
     }
 
-    protected internal Result(TValue? value, bool success, Error? error) : base(success, error)
+    protected internal Result(TValue? value, bool success, MicrosoftAuthenticationError? microsoftAuthenticationError) : base(success, microsoftAuthenticationError)
     {
         if (value == null && success)
             throw new InvalidOperationException("Pass a value if result is successful");
-
         Value = value;
     }
 
@@ -73,7 +71,7 @@ public class Result<TValue> : Result
     public static implicit operator TValue(Result<TValue> from) => from.Value!;
 
     public Result<TValue> Match(Func<TValue, Result<TValue>> success,
-                                        Func<Error, Result<TValue>> failure)
+                                Func<MicrosoftAuthenticationError, Result<TValue>> failure)
     {
         if (IsSuccess)
         {

--- a/AIERA.Desktop.WinForms/LoginForm.cs
+++ b/AIERA.Desktop.WinForms/LoginForm.cs
@@ -2,7 +2,6 @@
 using AIERA.Desktop.WinForms.Authentication.Models.Result_Pattern;
 using AIERA.Desktop.WinForms.IoC.Factories;
 using AIERA.Desktop.WinForms.Models.ViewModels;
-using Common.Models;
 using System.ComponentModel;
 
 namespace AIERA.Desktop.WinForms;
@@ -12,7 +11,7 @@ public partial class LoginForm : Form
     private readonly IMicrosoftAuthentication _microsoftAuthentication;
 
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError>? MicrosoftAuthenticationResult { get; private set; }
+    public Result<MicrosoftAccountViewModel>? MicrosoftAuthenticationResult { get; private set; }
 
     private readonly CancellationTokenSource _loginFormClosingCancellationTokenSource = new();
 

--- a/AIERA.Desktop.WinForms/SettingsForm.Designer.cs
+++ b/AIERA.Desktop.WinForms/SettingsForm.Designer.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel;
 using AIERA.Desktop.WinForms.Authentication.Models.Result_Pattern;
 using AIERA.Desktop.WinForms.Models.ViewModels;
-using Common.Models;
 
 namespace AIERA.Desktop.WinForms;
 
@@ -406,7 +405,7 @@ partial class SettingsForm
     /// <summary>
     /// Creates a button from account data.
     /// </summary>
-    private Button CreateButtonFromAccountData(Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError> authenticationResult)
+    private Button CreateButtonFromAccountData(Result<MicrosoftAccountViewModel> authenticationResult)
     {
         Button btnAccount = new Button();
         btnAccount.ApplyAccountButtonTemplateProperties(btnMicrosoftAccount_Template);
@@ -417,7 +416,7 @@ partial class SettingsForm
     }
 
 
-    private void ApplyAccountDataToButton(Button btnAccount, Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError> authenticationResult)
+    private void ApplyAccountDataToButton(Button btnAccount, Result<MicrosoftAccountViewModel> authenticationResult)
     {
         MicrosoftAccountViewModel microsoftAccountViewModel = authenticationResult.GetMicrosoftAccountViewModel();
 
@@ -475,7 +474,7 @@ partial class SettingsForm
     /// Updates already existing account button or creates a new account button and inserts it in the list/panel of accounts.
     /// </summary>
     /// <param name="authenticationResult"><see cref="Result"/> that contains the account data that will be added to the button.</param>
-    public void UpsertAccountButton(Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError> authenticationResult)
+    public void UpsertAccountButton(Result<MicrosoftAccountViewModel> authenticationResult)
     {
         MicrosoftAccountViewModel microsoftAccountViewModel = authenticationResult.GetMicrosoftAccountViewModel();
 

--- a/AIERA.Desktop.WinForms/Toaster/ToastActionHandlers/Handlers/AcquireTokenInteractivelyHandler.cs
+++ b/AIERA.Desktop.WinForms/Toaster/ToastActionHandlers/Handlers/AcquireTokenInteractivelyHandler.cs
@@ -3,7 +3,6 @@ using AIERA.Desktop.WinForms.Authentication.Models.Result_Pattern;
 using AIERA.Desktop.WinForms.IoC.Factories;
 using AIERA.Desktop.WinForms.Models.ViewModels;
 using AIERA.Desktop.WinForms.Toaster.Enums;
-using Common.Models;
 using Microsoft.Toolkit.Uwp.Notifications;
 
 namespace AIERA.Desktop.WinForms.Toaster.ToastActionHandlers.Handlers;
@@ -46,7 +45,7 @@ public class AcquireTokenInteractivelyHandler : IToastActionHandler
                     throw task.Exception; // LOG
                 }
 
-                Result<MicrosoftAccountViewModel, MicrosoftAuthenticationError> authResult = task.Result;
+                Result<MicrosoftAccountViewModel> authResult = task.Result;
 
                 MicrosoftAccountViewModel accountViewModel = authResult.GetMicrosoftAccountViewModel();
 

--- a/Common/Models/Result Pattern/Error.cs
+++ b/Common/Models/Result Pattern/Error.cs
@@ -10,8 +10,8 @@ public class Error
         Message = message;
     }
 
-    public static Error TaskCancelledExceptionError(string errorMessage)
-        => new("MicrosoftAuthenticationError.AcquireTokenSilentError.TaskCanceledException", errorMessage);
+    //public static Error TaskCancelledExceptionError(string errorMessage)
+    //    => new("Error.TaskCanceledException", errorMessage);
 
     public override int GetHashCode()
     {


### PR DESCRIPTION
Refactor Result class to use specific error type

Refactored the `Result` class to remove the generic error type `TError` and added a new 'Result' class in the 'AIERA.Desktop:WinForms' project, with the specific `MicrosoftAuthenticationError` type instead of just Error.